### PR TITLE
Add support for filesystem cache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,4 @@ trickster_tracing:
       - exporter = 'noop'
       - collector = ''
       - sample_rate = 1.0
+trickster_caches_filesystem_path: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ trickster_frontend_connections_limit: 0
 trickster_metrics_listen_port: 8082
 trickster_metrics_listen_address: 127.0.0.1
 trickster_logging_log_level: info
+trickster_logging_log_file: /var/log/trickster/trickster.log
 trickster_origins:
   - origin: prometheus
     config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-trickster_version: 1.0.1
+trickster_version: 1.1.3
 trickster_user: trickster_sv
 trickster_cli_flags: {}
 trickster_main_instance_id: 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: trickster
+  description: Install Trickster as a service
+
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,30 +15,23 @@
 - name: "Download trickster files"
   become: false
   get_url:
-    url: "https://github.com/Comcast/trickster/releases/download/v{{ trickster_version }}/trickster-{{ trickster_version }}.linux-amd64.tar.gz"
+    url: "https://github.com/Comcast/trickster/releases/download/v{{ trickster_version }}/trickster-{{ trickster_version }}.tar.gz"
     dest: "/tmp/"
-  delegate_to: localhost
-
-- name: "Create temporary directory"
-  become: false
-  file:
-    path: /tmp/trickster_{{trickster_version}}_linux_amd64
-    state: directory
   delegate_to: localhost
 
 - name: "Unarchive trickster files"
   become: false
   unarchive:
-    src: "/tmp/trickster-{{ trickster_version }}.linux-amd64.tar.gz"
+    src: "/tmp/trickster-{{ trickster_version }}.tar.gz"
     remote_src: yes
-    dest: "/tmp/trickster_{{trickster_version}}_linux_amd64/"
-    creates: "/tmp/trickster_{{trickster_version}}_linux_amd64/OPATH/trickster-{{ trickster_version }}.linux-amd64"
+    dest: "/tmp/"
+    creates: "/tmp/trickster-{{trickster_version}}/./bin/trickster-{{ trickster_version }}.linux-amd64"
   delegate_to: localhost
   check_mode: false
 
 - name: propagate trickster binary
   copy:
-    src: "/tmp/trickster_{{trickster_version}}_linux_amd64/OPATH/trickster-{{ trickster_version }}.linux-amd64"
+    src: "/tmp/trickster-{{trickster_version}}/./bin/trickster-{{ trickster_version }}.linux-amd64"
     dest: "/usr/local/bin/trickster"
     mode: 0755
     owner: "{{ trickster_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,15 @@
   notify:
     - restart trickster
 
+- name: ensure trickster cache dir is created
+  file:
+    path: "{{ trickster_caches_filesystem_path }}"
+    state: directory
+    owner: "{{ trickster_user }}"
+    group: "{{ trickster_user }}"
+    mode: '0755'
+  when: trickster_caches_filesystem_path != ""
+
 - name: Generate trickster config file
   template:
       dest: /etc/trickster.conf

--- a/templates/trickster.conf.j2
+++ b/templates/trickster.conf.j2
@@ -44,6 +44,14 @@ connections_limit = {{ trickster_frontend_connections_limit }}
       {{ items }}
 {% endfor %}
 {% endif %}
+
+{% if item.filesystem is defined and item.filesystem is iterable %}
+      [caches.{{ item.cache }}.filesystem]
+{% for items in item.filesystem %}
+      {{ items }}
+{% endfor %}
+{% endif %}
+
 {% endfor %}
 {% endif %}
 

--- a/templates/trickster.conf.j2
+++ b/templates/trickster.conf.j2
@@ -55,6 +55,19 @@ connections_limit = {{ trickster_frontend_connections_limit }}
 {% endfor %}
 {% endif %}
 
+{% if trickster_request_rewriters is defined and trickster_request_rewriters is iterable %}
+[request_rewriters]
+{% for item in trickster_request_rewriters %}
+  [request_rewriters.{{ item.name }}]
+  instructions = [
+{% for instruction in item.instructions %}
+    {{ instruction }}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ]
+{% endfor %}
+{% endif %}
+
 {% if trickster_origins is defined and trickster_origins is iterable %}
 [origins]
 {% for item in trickster_origins %}
@@ -100,4 +113,4 @@ listen_address = '{{ trickster_metrics_listen_address }}'
 
 [logging]
 log_level = '{{ trickster_logging_log_level }}'
-#log_file = '/some/path/to/trickster.log'
+log_file = '{{ trickster_logging_log_file }}'


### PR DESCRIPTION
Hey, I added filesystem cache to the template file + added a step that creates a cache dir with correct access rights. 

Also I needed to add galaxy meta info in orded to use ansible-galaxy to install this role. I think you should change this to include author info, license, etc.
Take a look if you think this can be merged.